### PR TITLE
Improve conversation panel with session history

### DIFF
--- a/chatbot-react/src/App.css
+++ b/chatbot-react/src/App.css
@@ -66,6 +66,10 @@
   transition: margin-right 0.3s ease;
 }
 
+.chat-content.with-left-sidebar {
+  margin-left: 220px;
+}
+
 .chat-content.with-sidebar {
   margin-right: 350px;
 }
@@ -178,11 +182,17 @@
   .chat-content.with-sidebar {
     margin-right: 300px;
   }
+  .chat-content.with-left-sidebar {
+    margin-left: 200px;
+  }
 }
 
 @media (max-width: 1024px) {
   .chat-content.with-sidebar {
     margin-right: 0;
+  }
+  .chat-content.with-left-sidebar {
+    margin-left: 0;
   }
   
   .scroll-to-latest-button {

--- a/chatbot-react/src/components/ChatPage.jsx
+++ b/chatbot-react/src/components/ChatPage.jsx
@@ -8,6 +8,7 @@ import UserSelector from './UserSelector';
 import UserProfile from './UserProfile';
 import UserDropdown from './UserDropdown';
 import ConversationTopics from './ConversationTopics';
+import SessionHistorySidebar from './SessionHistorySidebar';
 import { getModels, sendChatMessage, getCurrentUser } from '../services/api';
 import { generateDisplayName } from '../utils/userUtils';
 import '../App.css';
@@ -346,6 +347,7 @@ const ChatPage = () => {
 
   return (
     <div className="chat-container">
+      <SessionHistorySidebar />
       <div className="chat-header">
         <h1>AI Chatbot</h1>
         <div className="header-controls">
@@ -386,8 +388,8 @@ const ChatPage = () => {
         </div>
       )}
       
-      <div 
-        className={`chat-content ${!isTopicsSidebarCollapsed ? 'with-sidebar' : ''}`}
+      <div
+        className={`chat-content with-left-sidebar ${!isTopicsSidebarCollapsed ? 'with-sidebar' : ''}`}
       >
         <div className="chat-messages" id="chat-messages" ref={chatContainerRef}>
           {messages.map((msg, index) => (

--- a/chatbot-react/src/components/SessionHistorySidebar.jsx
+++ b/chatbot-react/src/components/SessionHistorySidebar.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useSession } from '../context/SessionContext';
+import '../styles/SessionHistorySidebar.css';
+
+const SessionHistorySidebar = () => {
+  const {
+    userId,
+    sessionHistory,
+    sessionId,
+    updateSessionId,
+    updateMessages,
+    resetSession,
+  } = useSession();
+
+  const loadSession = (sid) => {
+    if (!userId) return;
+    const stored = localStorage.getItem(`chat_messages_${userId}_${sid}`);
+    if (stored) {
+      try {
+        updateMessages(JSON.parse(stored));
+      } catch {
+        updateMessages([
+          { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" },
+        ]);
+      }
+    } else {
+      updateMessages([
+        { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" },
+      ]);
+    }
+    updateSessionId(sid);
+  };
+
+  const handleNewSession = () => {
+    resetSession();
+  };
+
+  return (
+    <div className="session-history-sidebar">
+      <div className="sidebar-header">
+        <h3>Sessions</h3>
+        <button className="new-session-btn" onClick={handleNewSession} title="Start new session">
+          +
+        </button>
+      </div>
+      <ul className="session-list">
+        {sessionHistory.map((sid) => (
+          <li key={sid} className={sid === sessionId ? 'active' : ''}>
+            <button onClick={() => loadSession(sid)}>{sid.slice(-8)}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SessionHistorySidebar;

--- a/chatbot-react/src/components/TopicSidebarItem.jsx
+++ b/chatbot-react/src/components/TopicSidebarItem.jsx
@@ -41,39 +41,24 @@ const TopicSidebarItem = ({ topic, index, onEnableResearch, onDisableResearch, o
 
   return (
     <div className={`topic-list-item ${topic.is_active_research ? 'active-research' : ''}`}>
-      <div className="topic-main-content">
-        {/* Topic Header Row */}
-        <div className="topic-header-row">
-          <div className="topic-info">
-            <div className="topic-title">
-              <h4 className="topic-name" title={topic.name}>
-                {topic.name}
-              </h4>
-              {topic.is_active_research && (
-                <span className="research-status-badge">
-                  <span className="badge-icon">🔬</span>
-                  <span className="badge-text">RESEARCHING</span>
-                </span>
-              )}
-            </div>
-            
-            <div className="topic-confidence">
-              <div className={`confidence-bar-container ${confidenceClass}`}>
-                <div 
-                  className="confidence-fill"
-                  style={{ width: `${confidencePercentage}%` }}
-                ></div>
-              </div>
-              <span className="confidence-label">{confidencePercentage}% confidence</span>
-            </div>
+      <div className="topic-summary" onClick={() => setIsExpanded(!isExpanded)}>
+        <span className="topic-name" title={topic.name}>{topic.name}</span>
+        {topic.is_active_research && (
+          <span className="research-status-badge">
+            <span className="badge-icon">🔬</span>
+          </span>
+        )}
+        <button
+          className="action-btn expand-btn"
+          onClick={(e) => { e.stopPropagation(); setIsExpanded(!isExpanded); }}
+          title={isExpanded ? 'Show less' : 'Show more'}
+        >
+          <span className="btn-icon">{isExpanded ? '▲' : '▼'}</span>
+        </button>
+      </div>
 
-            {topic.description && (
-              <p className="topic-description-preview">
-                {topic.description.length > 120 ? topic.description.substring(0, 120) + '...' : topic.description}
-              </p>
-            )}
-          </div>
-
+      {isExpanded && (
+        <div className="topic-details-expanded">
           <div className="topic-actions">
             {!topic.is_active_research ? (
               <button
@@ -123,62 +108,49 @@ const TopicSidebarItem = ({ topic, index, onEnableResearch, onDisableResearch, o
                 </>
               )}
             </button>
-
-            <button
-              className="action-btn expand-btn"
-              onClick={() => setIsExpanded(!isExpanded)}
-              title={isExpanded ? 'Show less' : 'Show more'}
-            >
-              <span className="btn-icon">{isExpanded ? '▲' : '▼'}</span>
-            </button>
           </div>
-        </div>
 
-        {/* Expanded Details */}
-        {isExpanded && (
-          <div className="topic-details-expanded">
-            <div className="details-grid">
-              {topic.description && (
-                <div className="detail-section">
-                  <label className="detail-label">Full Description</label>
-                  <p className="detail-content">{topic.description}</p>
-                </div>
-              )}
-
-              {topic.conversation_context && (
-                <div className="detail-section">
-                  <label className="detail-label">Context from Conversation</label>
-                  <p className="detail-content context-text">
-                    "{topic.conversation_context}"
-                  </p>
-                </div>
-              )}
-
+          <div className="details-grid">
+            {topic.description && (
               <div className="detail-section">
-                <label className="detail-label">Topic Metadata</label>
-                <div className="metadata-grid">
-                  <div className="metadata-item">
-                    <span className="metadata-key">Confidence:</span>
-                    <span className="metadata-value">{confidencePercentage}%</span>
-                  </div>
-                  <div className="metadata-item">
-                    <span className="metadata-key">Suggested:</span>
-                    <span className="metadata-value">
-                      {new Date(topic.suggested_at * 1000).toLocaleDateString()}
-                    </span>
-                  </div>
-                  <div className="metadata-item">
-                    <span className="metadata-key">Status:</span>
-                    <span className="metadata-value">
-                      {topic.is_active_research ? 'Active Research' : 'Suggested'}
-                    </span>
-                  </div>
+                <label className="detail-label">Full Description</label>
+                <p className="detail-content">{topic.description}</p>
+              </div>
+            )}
+
+            {topic.conversation_context && (
+              <div className="detail-section">
+                <label className="detail-label">Context from Conversation</label>
+                <p className="detail-content context-text">
+                  "{topic.conversation_context}"
+                </p>
+              </div>
+            )}
+
+            <div className="detail-section">
+              <label className="detail-label">Topic Metadata</label>
+              <div className="metadata-grid">
+                <div className="metadata-item">
+                  <span className="metadata-key">Confidence:</span>
+                  <span className="metadata-value">{confidencePercentage}%</span>
+                </div>
+                <div className="metadata-item">
+                  <span className="metadata-key">Suggested:</span>
+                  <span className="metadata-value">
+                    {new Date(topic.suggested_at * 1000).toLocaleDateString()}
+                  </span>
+                </div>
+                <div className="metadata-item">
+                  <span className="metadata-key">Status:</span>
+                  <span className="metadata-value">
+                    {topic.is_active_research ? 'Active Research' : 'Suggested'}
+                  </span>
                 </div>
               </div>
             </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/chatbot-react/src/context/SessionContext.jsx
+++ b/chatbot-react/src/context/SessionContext.jsx
@@ -19,6 +19,7 @@ export const SessionProvider = ({ children }) => {
   const [messages, setMessages] = useState([
     { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" }
   ]);
+  const [sessionHistory, setSessionHistory] = useState([]);
   const [userDisplayName, setUserDisplayName] = useState('');
   const [personality, setPersonality] = useState(null);
   const [conversationTopics, setConversationTopics] = useState([]);
@@ -31,37 +32,52 @@ export const SessionProvider = ({ children }) => {
       ]);
       setSessionId(null);
       setConversationTopics([]);
+      setSessionHistory([]);
       return;
     }
 
     // Load stored messages
-    const storedMessages = localStorage.getItem(`chat_messages_${userId}`);
-    if (storedMessages) {
+    const storedHistory = localStorage.getItem(`session_history_${userId}`);
+    if (storedHistory) {
       try {
-        setMessages(JSON.parse(storedMessages));
+        setSessionHistory(JSON.parse(storedHistory));
       } catch {
-        // ignore parse errors
+        setSessionHistory([]);
       }
+    } else {
+      setSessionHistory([]);
     }
+
+    setMessages([
+      { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" }
+    ]);
 
     // Load stored session ID
     const storedSession = localStorage.getItem(`session_id_${userId}`);
     if (storedSession) {
       setSessionId(storedSession);
     }
-  }, [userId]);
+  }, [userId, sessionHistory]);
 
   // Persist conversation to localStorage
   useEffect(() => {
-    if (userId && messages.length > 1) { // Only persist if there are actual messages
-      localStorage.setItem(`chat_messages_${userId}`, JSON.stringify(messages));
+    if (userId && sessionId && messages.length > 0) {
+      localStorage.setItem(
+        `chat_messages_${userId}_${sessionId}`,
+        JSON.stringify(messages)
+      );
     }
-  }, [messages, userId]);
+  }, [messages, userId, sessionId]);
 
   // Persist session ID
   useEffect(() => {
     if (userId && sessionId) {
       localStorage.setItem(`session_id_${userId}`, sessionId);
+      setSessionHistory(prev => {
+        const updated = prev.includes(sessionId) ? prev : [...prev, sessionId];
+        localStorage.setItem(`session_history_${userId}`, JSON.stringify(updated));
+        return updated;
+      });
     }
   }, [sessionId, userId]);
 
@@ -99,7 +115,10 @@ export const SessionProvider = ({ children }) => {
     } else {
       // Clear user data when switching to no user
       if (userId) {
-        localStorage.removeItem(`chat_messages_${userId}`);
+        sessionHistory.forEach((sid) => {
+          localStorage.removeItem(`chat_messages_${userId}_${sid}`);
+        });
+        localStorage.removeItem(`session_history_${userId}`);
         localStorage.removeItem(`session_id_${userId}`);
       }
       setUserId('');
@@ -120,11 +139,26 @@ export const SessionProvider = ({ children }) => {
 
   const updateMessages = useCallback((newMessages) => {
     setMessages(newMessages);
-  }, []);
+    if (userId && sessionId) {
+      localStorage.setItem(
+        `chat_messages_${userId}_${sessionId}`,
+        JSON.stringify(newMessages)
+      );
+    }
+  }, [userId, sessionId]);
 
   const addMessage = useCallback((message) => {
-    setMessages(prev => [...prev, message]);
-  }, []);
+    setMessages(prev => {
+      const updated = [...prev, message];
+      if (userId && sessionId) {
+        localStorage.setItem(
+          `chat_messages_${userId}_${sessionId}`,
+          JSON.stringify(updated)
+        );
+      }
+      return updated;
+    });
+  }, [userId, sessionId]);
 
   const updatePersonality = useCallback((newPersonality) => {
     setPersonality(newPersonality);
@@ -138,15 +172,37 @@ export const SessionProvider = ({ children }) => {
     setConversationTopics(topics);
   }, []);
 
+  // Load messages when session changes
+  useEffect(() => {
+    if (userId && sessionId) {
+      const stored = localStorage.getItem(`chat_messages_${userId}_${sessionId}`);
+      if (stored) {
+        try {
+          setMessages(JSON.parse(stored));
+        } catch {
+          setMessages([
+            { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" }
+          ]);
+        }
+      } else {
+        setMessages([
+          { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" }
+        ]);
+      }
+    }
+  }, [sessionId, userId]);
+
   const resetSession = useCallback(() => {
     setMessages([
       { role: 'system', content: "Hello! I'm your AI assistant. How can I help you today?" }
     ]);
     setSessionId(null);
     setConversationTopics([]);
-    
+
     if (userId) {
-      localStorage.removeItem(`chat_messages_${userId}`);
+      if (sessionId) {
+        localStorage.removeItem(`chat_messages_${userId}_${sessionId}`);
+      }
       localStorage.removeItem(`session_id_${userId}`);
     }
   }, [userId]);
@@ -159,6 +215,7 @@ export const SessionProvider = ({ children }) => {
     userDisplayName,
     personality,
     conversationTopics,
+    sessionHistory,
     
     // Actions
     updateUserId,

--- a/chatbot-react/src/styles/ConversationTopics.css
+++ b/chatbot-react/src/styles/ConversationTopics.css
@@ -1,6 +1,6 @@
 .conversation-topics {
   width: 350px;
-  height: 100vh;
+  height: calc(100vh - 110px);
   border-left: 1px solid #e5e7eb;
   background: #f9fafb;
   display: flex;
@@ -8,7 +8,7 @@
   overflow: hidden;
   position: fixed;
   right: 0;
-  top: 0;
+  top: 110px;
   z-index: 1000;
 }
 
@@ -16,6 +16,8 @@
   width: 50px;
   background: #f3f4f6;
   border-left: 1px solid #e5e7eb;
+  top: 110px;
+  height: calc(100vh - 110px);
 }
 
 .expand-button {

--- a/chatbot-react/src/styles/SessionHistorySidebar.css
+++ b/chatbot-react/src/styles/SessionHistorySidebar.css
@@ -1,0 +1,51 @@
+.session-history-sidebar {
+  width: 220px;
+  position: fixed;
+  left: 0;
+  top: 110px;
+  bottom: 0;
+  background: #f9fafb;
+  border-right: 1px solid #e5e7eb;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.new-session-btn {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.session-list li {
+  padding: 0;
+}
+
+.session-list button {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-list li.active button {
+  background: #e5e7eb;
+}

--- a/chatbot-react/src/styles/TopicSidebarItem.css
+++ b/chatbot-react/src/styles/TopicSidebarItem.css
@@ -8,6 +8,14 @@
   position: relative;
 }
 
+.topic-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+}
+
 .topic-list-item:first-child {
   border-top: 1px solid #e5e7eb;
 }


### PR DESCRIPTION
## Summary
- add left sidebar for session history
- shift chat content to make room for new sidebar
- make research topics sidebar respect top bars
- show topics as compact list items
- track sessions and messages per session

## Testing
- `npm test --silent --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `bash backend/run_tests.sh` *(fails: ImportError: cannot import name 'WithJsonSchema')*

------
https://chatgpt.com/codex/tasks/task_b_683feaf64b64832798f682ffa79a534c