### PR TITLE
Add dynamic conversation titles

### DIFF
--- a/chatbot-react/src/components/ChatPage.jsx
+++ b/chatbot-react/src/components/ChatPage.jsx
@@ -27,6 +27,8 @@ const ChatPage = () => {
     updatePersonality,
     updateUserDisplayName,
     updateConversationTopics,
+    sessionTitles,
+    updateSessionTitle,
   } = useSession();
 
   // Local state for UI components
@@ -348,7 +350,15 @@ const ChatPage = () => {
 
   const handleTopicUpdate = useCallback((topics) => {
     updateConversationTopics(topics);
-  }, [updateConversationTopics]);
+    if (
+      topics &&
+      topics.length > 0 &&
+      sessionId &&
+      sessionTitles[sessionId] === 'new conversation'
+    ) {
+      updateSessionTitle(sessionId, topics[0].name);
+    }
+  }, [updateConversationTopics, sessionId, sessionTitles, updateSessionTitle]);
 
   return (
     <div className="chat-container">

--- a/chatbot-react/src/components/SessionHistory.jsx
+++ b/chatbot-react/src/components/SessionHistory.jsx
@@ -3,7 +3,13 @@ import { useSession } from '../context/SessionContext';
 import '../styles/SessionHistory.css';
 
 const SessionHistory = () => {
-  const { sessionHistory, sessionId, switchSession, startNewSession } = useSession();
+  const {
+    sessionHistory,
+    sessionId,
+    sessionTitles,
+    switchSession,
+    startNewSession
+  } = useSession();
 
   return (
     <div className="session-history">
@@ -12,7 +18,7 @@ const SessionHistory = () => {
         {sessionHistory.map((id) => (
           <li key={id} className={id === sessionId ? 'active' : ''}>
             <button type="button" onClick={() => switchSession(id)}>
-              {id.slice(-8)}
+              {sessionTitles[id] || id.slice(-8)}
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- display short titles instead of raw session IDs
- persist titles in `SessionContext`
- update the title based on topic suggestions

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684262a4dcdc8327b6f4b9bf0fa7d149