### PR TITLE
Add Zep knowledge graph viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A full-stack prototype that pairs a conversational AI with an autonomous backgro
 * React 19 front-end
 * FastAPI + LangGraph back-end
 * Motivation-driven research scheduler
+* Optional Zep memory with knowledge graph
 * JWT-secured admin console & prompt editor
 * Local JSON storage – no external DB needed
 

--- a/backend/api/graph.py
+++ b/backend/api/graph.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends, HTTPException
+from dependencies import get_existing_user_id, zep_manager
+from logging_config import get_logger
+
+router = APIRouter()
+logger = get_logger(__name__)
+
+
+@router.get("/graph")
+async def get_graph(user_id: str = Depends(get_existing_user_id)):
+    if not user_id:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    data = await zep_manager.get_knowledge_graph(user_id)
+    if data is None:
+        raise HTTPException(status_code=500, detail="Failed to fetch knowledge graph")
+
+    return data

--- a/backend/app.py
+++ b/backend/app.py
@@ -26,7 +26,14 @@ class MotivationConfigUpdate(BaseModel):
     satisfaction_decay: Optional[float] = None
 
 
-from dependencies import storage_manager, profile_manager, research_manager, zep_manager, get_or_create_user_id, _motivation_config_override
+from dependencies import (
+    storage_manager,
+    profile_manager,
+    research_manager,
+    zep_manager,
+    get_or_create_user_id,
+    _motivation_config_override,
+)
 from autonomous_research_engine import initialize_autonomous_researcher
 
 # Global motivation config override (persists across reinitializations)
@@ -44,7 +51,9 @@ async def lifespan(app: FastAPI):
     try:
         logger.info("🔬 Initializing Autonomous Research Engine...")
         logger.info(f"App startup - Config override: {_motivation_config_override}")
-        app.state.autonomous_researcher = initialize_autonomous_researcher(profile_manager, research_manager, _motivation_config_override)
+        app.state.autonomous_researcher = initialize_autonomous_researcher(
+            profile_manager, research_manager, _motivation_config_override
+        )
         await app.state.autonomous_researcher.start()
         logger.info("🔬 Autonomous Research Engine initialized successfully")
     except Exception as e:
@@ -83,11 +92,13 @@ from api.users import router as users_router
 from api.topics import router as topics_router
 from api.research import router as research_router
 from api.admin import router as admin_router
+from api.graph import router as graph_router
 
 app.include_router(chat_router)
 app.include_router(users_router)
 app.include_router(topics_router)
 app.include_router(research_router)
+app.include_router(graph_router)
 app.include_router(admin_router)
 
 # Mount static files for diagrams

--- a/backend/storage/zep_manager.py
+++ b/backend/storage/zep_manager.py
@@ -2,40 +2,40 @@
 Zep Memory Manager for storing chat interactions in knowledge graph.
 """
 
-import uuid
 from typing import Optional, List, Dict, Any
 from zep_cloud.client import AsyncZep
 from zep_cloud import Message
 
 # Import the centralized logging configuration
 from logging_config import get_logger
+import config
+
 logger = get_logger(__name__)
 
-import config
 
 class ZepManager:
     """
     Simple Zep manager for storing user messages and AI responses in knowledge graph.
     Uses singleton pattern to prevent multiple instantiations and duplicate log messages.
     """
-    
+
     _instance = None
     _initialized = False
-    
+
     def __new__(cls):
         """Implement singleton pattern to ensure only one instance exists."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         """Initialize the Zep manager (only runs once due to singleton pattern)."""
         if self._initialized:
             return
-            
+
         self.enabled = config.ZEP_ENABLED
         self.client = None
-        
+
         if self.enabled and config.ZEP_API_KEY:
             try:
                 self.client = AsyncZep(api_key=config.ZEP_API_KEY)
@@ -45,31 +45,31 @@ class ZepManager:
                 self.enabled = False
         else:
             logger.info("Zep is disabled or API key not provided")
-        
+
         self._initialized = True
-    
+
     def is_enabled(self) -> bool:
         """Check if Zep is enabled and properly configured."""
         return self.enabled and self.client is not None
-    
+
     async def create_user(self, user_id: str, display_name: str = None) -> bool:
         """
         Create a user in Zep.
-        
+
         Args:
             user_id: The ID of the user (e.g., "happy-cat-42")
             display_name: Optional display name, will generate from user_id if not provided
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not self.is_enabled():
             return False
-        
+
         try:
             # Parse display name or generate from user_id
             first_name, last_name = self._parse_user_name(user_id, display_name)
-            
+
             # Check if user already exists
             try:
                 await self.client.user.get(user_id)
@@ -78,35 +78,31 @@ class ZepManager:
             except Exception:
                 # User doesn't exist, create them
                 pass
-            
+
             # Create user in Zep
-            await self.client.user.add(
-                user_id=user_id,
-                first_name=first_name,
-                last_name=last_name
-            )
-            
+            await self.client.user.add(user_id=user_id, first_name=first_name, last_name=last_name)
+
             logger.info(f"Created ZEP user: {user_id} ({first_name} {last_name})")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to create user in Zep: {str(e)}")
             return False
-    
+
     async def create_session(self, session_id: str, user_id: str) -> bool:
         """
         Create a session in Zep.
-        
+
         Args:
             session_id: The session ID
             user_id: The user ID that owns this session
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not self.is_enabled():
             return False
-        
+
         try:
             # Check if session already exists
             try:
@@ -116,13 +112,10 @@ class ZepManager:
             except Exception:
                 # Session doesn't exist, create it
                 pass
-            
+
             # Try to create session - this will fail if user doesn't exist
             try:
-                await self.client.memory.add_session(
-                    session_id=session_id,
-                    user_id=user_id
-                )
+                await self.client.memory.add_session(session_id=session_id, user_id=user_id)
                 logger.info(f"Created ZEP session: {session_id} for user {user_id}")
                 return True
             except Exception as e:
@@ -130,27 +123,24 @@ class ZepManager:
                 # Try creating user first, then session
                 logger.debug(f"Session creation failed, ensuring user exists: {str(e)}")
                 await self.create_user(user_id)
-                
+
                 # Try session creation again
-                await self.client.memory.add_session(
-                    session_id=session_id,
-                    user_id=user_id
-                )
+                await self.client.memory.add_session(session_id=session_id, user_id=user_id)
                 logger.info(f"Created ZEP session: {session_id} for user {user_id} (after creating user)")
                 return True
-            
+
         except Exception as e:
             logger.error(f"Failed to create session in Zep: {str(e)}")
             return False
-    
+
     def _parse_user_name(self, user_id: str, display_name: str = None) -> tuple[str, str]:
         """
         Parse first and last name from user_id or display_name.
-        
+
         Args:
             user_id: The user ID (e.g., "happy-cat-42")
             display_name: Optional display name (e.g., "Happy Cat 42")
-            
+
         Returns:
             Tuple of (first_name, last_name)
         """
@@ -165,8 +155,8 @@ class ZepManager:
                 last_name = ""
         else:
             # Parse from user_id (adjective-noun-number)
-            if len(user_id.split('-')) == 3 and not user_id.startswith('user-'):
-                parts = user_id.split('-')
+            if len(user_id.split("-")) == 3 and not user_id.startswith("user-"):
+                parts = user_id.split("-")
                 adjective = parts[0].capitalize()
                 noun = parts[1].capitalize()
                 number = parts[2]
@@ -176,105 +166,100 @@ class ZepManager:
                 # Fallback for non-standard user IDs
                 first_name = "User"
                 last_name = user_id[-6:] if len(user_id) > 6 else user_id
-        
-        logger.info(f"🏷️  Parsed name for user {user_id}: '{first_name} {last_name}' (from {'display_name' if display_name else 'user_id'})")
+
+        logger.info(
+            "🏷️  Parsed name for user %s: '%s %s' (from %s)",
+            user_id,
+            first_name,
+            last_name,
+            "display_name" if display_name else "user_id",
+        )
         return first_name, last_name
 
-    async def store_conversation_turn(
-        self, 
-        user_id: str, 
-        user_message: str, 
-        ai_response: str,
-        session_id: str
-    ) -> bool:
+    async def store_conversation_turn(self, user_id: str, user_message: str, ai_response: str, session_id: str) -> bool:
         """
         Store a conversation turn (user message + AI response) in Zep.
-        
+
         Args:
             user_id: The ID of the user
             user_message: The user's message content
             ai_response: The AI's response content
             session_id: The session ID (must be provided)
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not self.is_enabled():
             logger.debug("Zep is not enabled, skipping storage")
             return False
-        
+
         if not session_id:
             logger.error("Session ID is required for storing conversation turn")
             return False
-        
+
         try:
             # Add user message
             user_success = await self.add_message(session_id, user_message, "user")
             if not user_success:
                 return False
-            
+
             # Add assistant response
             assistant_success = await self.add_message(session_id, ai_response, "assistant")
             if not assistant_success:
                 return False
-            
+
             logger.debug(f"Stored conversation turn for user {user_id} in session {session_id}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to store conversation in Zep: {str(e)}")
             return False
-    
+
     async def get_memory_context(self, session_id: str) -> Optional[str]:
         """
         Get memory context for a session.
-        
+
         Args:
             session_id: The session ID to get context for
-            
+
         Returns:
             Memory context string or None if not available
         """
         if not self.is_enabled():
             return None
-        
+
         try:
             # Memory retrieval currently uses session_id as the key, but it does
             # retrieve larger memory context.
             # TODO: Compare with use of zep.graph.search() on nodes and edges.
             memory = await self.client.memory.get(session_id=session_id)
             return memory.context if memory else None
-            
+
         except Exception as e:
             # Log but don't error - this could be because session doesn't exist yet
             # which is normal for new sessions
             logger.debug(f"No memory context found for session {session_id}: {str(e)}")
             return None
-    
+
     async def search_user_facts(self, user_id: str, query: str, limit: int = 5) -> List[str]:
         """
         Search for facts related to a user.
-        
+
         Args:
             user_id: The user ID to search for
             query: The search query
             limit: Maximum number of results to return
-            
+
         Returns:
             List of facts matching the query
         """
         if not self.is_enabled():
             return []
-        
+
         try:
-            edges = await self.client.graph.search(
-                user_id=user_id, 
-                text=query, 
-                limit=limit, 
-                search_scope="edges"
-            )
+            edges = await self.client.graph.search(user_id=user_id, text=query, limit=limit, search_scope="edges")
             return [edge.fact for edge in edges if edge.fact]
-            
+
         except Exception as e:
             logger.error(f"Failed to search user facts in Zep: {str(e)}")
             return []
@@ -282,32 +267,46 @@ class ZepManager:
     async def add_message(self, session_id: str, content: str, role_type: str = "system") -> bool:
         """
         Add a single message to a session.
-        
+
         Args:
             session_id: The session ID
             content: The message content
             role_type: The role type (system, user, assistant)
-            
+
         Returns:
             True if successful, False otherwise
         """
         if not self.is_enabled():
             return False
-        
+
         try:
-            message = Message(
-                role_type=role_type,
-                content=content
-            )
-            
-            await self.client.memory.add(
-                session_id=session_id,
-                messages=[message]
-            )
-            
+            message = Message(role_type=role_type, content=content)
+
+            await self.client.memory.add(session_id=session_id, messages=[message])
+
             logger.debug(f"Added {role_type} message to session {session_id}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to add message to session {session_id}: {str(e)}")
-            return False 
+
+            return False
+
+    async def get_knowledge_graph(self, user_id: str, limit: int = 100) -> Optional[Dict[str, Any]]:
+        """Retrieve the knowledge graph for a user."""
+        if not self.is_enabled():
+            return None
+
+        try:
+            results = await self.client.graph.search(
+                query="",
+                user_id=user_id,
+                limit=limit,
+                scope="edges",
+            )
+            edges = [e.dict() for e in results.edges or []]
+            nodes = [n.dict() for n in results.nodes or []]
+            return {"nodes": nodes, "edges": edges}
+        except Exception as e:
+            logger.error(f"Failed to fetch knowledge graph for {user_id}: {str(e)}")
+            return None

--- a/backend/tests/unit/test_api_graph.py
+++ b/backend/tests/unit/test_api_graph.py
@@ -1,0 +1,35 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from fastapi import FastAPI
+from api.graph import router
+from dependencies import get_existing_user_id, zep_manager
+
+app = FastAPI()
+app.include_router(router)
+
+
+@pytest.fixture
+def client():
+    def get_test_user_id():
+        return "test_user"
+
+    app.dependency_overrides[get_existing_user_id] = get_test_user_id
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def mock_graph(monkeypatch):
+    async def fake_graph(user_id: str, limit: int = 100):
+        return {"nodes": [{"uuid": "n1", "name": "User"}], "edges": []}
+
+    monkeypatch.setattr(zep_manager, "get_knowledge_graph", fake_graph)
+
+
+def test_get_knowledge_graph(client):
+    res = client.get("/graph")
+    assert res.status_code == 200
+    data = res.json()
+    assert "nodes" in data and "edges" in data

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -76,13 +76,19 @@ Findings appear underneath each topic with:
 
 ---
 
-## 6. Motivation Dashboard
+## 6. Memory Graph
+
+Click **Memory Graph** in the header to view a visualisation of the knowledge stored in Zep for the current user. Nodes represent entities while lines show facts linking them.
+
+---
+
+## 7. Motivation Dashboard
 
 Press the 💡 icon to open real-time bars for **boredom**, **curiosity**, **tiredness** and **satisfaction**.  When boredom + curiosity ≥ threshold a new research cycle is launched automatically.
 
 ---
 
-## 7. Admin Console (optional)
+## 8. Admin Console (optional)
 
 For advanced users / administrators.
 
@@ -95,7 +101,7 @@ For advanced users / administrators.
 
 ---
 
-## 8. Keyboard Shortcuts
+## 9. Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
@@ -106,13 +112,13 @@ For advanced users / administrators.
 
 ---
 
-## 9. Logout & Clearing Data
+## 10. Logout & Clearing Data
 
 User data lives in `backend/storage_data/` (JSON).  Deleting a user or the directory will permanently erase associated chats, settings and research findings.  There is no cloud backup.
 
 ---
 
-## 10. Getting Help
+## 11. Getting Help
 
 * Hover tooltips explain most buttons.  
 * Logs appear in the terminal running the backend.  

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Navigation from './components/Navigation';
 import ChatPage from './components/ChatPage';
 import TopicsDashboard from './components/TopicsDashboard';
 import ResearchResultsDashboard from './components/ResearchResultsDashboard';
+import KnowledgeGraphPage from './components/KnowledgeGraphPage';
 import AdminLogin from './components/admin/AdminLogin';
 import AdminDashboard from './components/admin/AdminDashboard';
 import ProtectedAdminRoute from './components/admin/ProtectedAdminRoute';
@@ -41,6 +42,7 @@ function App() {
                       <Route path="/" element={<ChatPage />} />
                       <Route path="/topics" element={<TopicsDashboard />} />
                       <Route path="/research-results" element={<ResearchResultsDashboard />} />
+                      <Route path="/knowledge-graph" element={<KnowledgeGraphPage />} />
                     </Routes>
                   </main>
                 </>

--- a/frontend/src/components/KnowledgeGraphPage.jsx
+++ b/frontend/src/components/KnowledgeGraphPage.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { getKnowledgeGraph } from '../services/api';
+import '../styles/KnowledgeGraph.css';
+
+const circleLayout = (nodes, radius, cx, cy) => {
+  return nodes.map((n, idx) => {
+    const angle = (idx / nodes.length) * Math.PI * 2;
+    return { ...n, x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) };
+  });
+};
+
+const KnowledgeGraphPage = () => {
+  const [graph, setGraph] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getKnowledgeGraph();
+        setGraph(data);
+      } catch (e) {
+        console.error(e);
+        setError('Failed to load knowledge graph');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return <div className="knowledge-graph">Loading...</div>;
+  }
+  if (error) {
+    return <div className="knowledge-graph error">{error}</div>;
+  }
+  if (!graph || !graph.nodes?.length) {
+    return <div className="knowledge-graph">No data available</div>;
+  }
+
+  const positioned = circleLayout(graph.nodes, 200, 250, 250);
+  const map = {};
+  positioned.forEach(n => { map[n.uuid] = n; });
+
+  return (
+    <div className="knowledge-graph">
+      <h2>Memory Graph</h2>
+      <svg width="500" height="500">
+        {graph.edges.map(edge => {
+          const s = map[edge.source_node_uuid];
+          const t = map[edge.target_node_uuid];
+          if (!s || !t) return null;
+          return <line key={edge.uuid} x1={s.x} y1={s.y} x2={t.x} y2={t.y} stroke="#888" />;
+        })}
+        {positioned.map(node => (
+          <g key={node.uuid}>
+            <circle cx={node.x} cy={node.y} r={20} fill="#4caf50" />
+            <text x={node.x} y={node.y} textAnchor="middle" dy="5" fill="#fff" fontSize="10">
+              {node.name}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+export default KnowledgeGraphPage;

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -181,14 +181,20 @@ const Navigation = () => {
               >
                 🔍 Research Topics
               </Link>
-              <Link 
-                to="/research-results" 
+              <Link
+                to="/research-results"
                 className={`nav-link ${location.pathname === '/research-results' ? 'active' : ''}`}
               >
                 📊 Research Results
               </Link>
-              <Link 
-                to="/admin" 
+              <Link
+                to="/knowledge-graph"
+                className={`nav-link ${location.pathname === '/knowledge-graph' ? 'active' : ''}`}
+              >
+                🧠 Memory Graph
+              </Link>
+              <Link
+                to="/admin"
                 className={`nav-link admin-link ${location.pathname.startsWith('/admin') ? 'active' : ''}`}
                 title="Admin Panel - Prompt Management"
               >

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -425,4 +425,14 @@ export const restartResearchEngine = async () => {
   }
 };
 
-export default api; 
+export const getKnowledgeGraph = async () => {
+  try {
+    const response = await api.get('/graph');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching knowledge graph:', error);
+    throw error;
+  }
+};
+
+export default api;

--- a/frontend/src/styles/KnowledgeGraph.css
+++ b/frontend/src/styles/KnowledgeGraph.css
@@ -1,0 +1,12 @@
+.knowledge-graph {
+  padding: 1rem;
+  text-align: center;
+}
+
+.knowledge-graph svg {
+  border: 1px solid #ccc;
+}
+
+.knowledge-graph.error {
+  color: red;
+}


### PR DESCRIPTION
## Summary
- integrate Zep knowledge graph API endpoint
- expose new frontend route and button
- simple SVG knowledge graph renderer
- document Memory Graph feature

## Testing
- `black api/graph.py app.py storage/zep_manager.py tests/unit/test_api_graph.py --check`
- `flake8 api/graph.py storage/zep_manager.py tests/unit/test_api_graph.py`
- `./backend/run_tests.sh` *(fails: ImportError in tests/unit/test_prompts.py)*
- `npm run lint` *(fails: 11 errors)*
- `npm run test:unit` *(fails: 1 test failed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68675c78d8248327b918e04e4a84a41d