### PR TITLE
frontend: persist and render session titles via localStorage; set on …

### DIFF
--- a/frontend/src/components/ChatPage.jsx
+++ b/frontend/src/components/ChatPage.jsx
@@ -18,6 +18,8 @@ const ChatPage = () => {
     updateSessionId,
     updateMessages,
     updateConversationTopics,
+    sessionTitles,
+    setSessionTitle,
   } = useSession();
 
   const { trackSessionContinuation } = useEngagementTracking();
@@ -119,7 +121,20 @@ const ChatPage = () => {
       
       // Store session ID for conversation continuity
       if (response.session_id) {
-        updateSessionId(response.session_id);
+        const newSid = response.session_id;
+        updateSessionId(newSid);
+        // Set title from first user message if not already set
+        try {
+          const existing = sessionTitles?.[newSid];
+          if (!existing) {
+            const firstUser = updatedMessages.find(m => m.role === 'user');
+            if (firstUser && firstUser.content) {
+              const raw = String(firstUser.content).trim();
+              const title = raw.length > 60 ? raw.slice(0, 57) + '…' : raw;
+              if (title) setSessionTitle(newSid, title);
+            }
+          }
+        } catch {}
       }
       
       // Combine routing_analysis (detailed metrics) with module_used (fallback)

--- a/frontend/src/components/SessionHistory.jsx
+++ b/frontend/src/components/SessionHistory.jsx
@@ -30,7 +30,7 @@ const formatSessionId = (id) => {
 };
 
 const SessionHistory = () => {
-  const { sessionHistory, sessionId, switchSession, startNewSession } = useSession();
+  const { sessionHistory, sessionId, switchSession, startNewSession, sessionTitles } = useSession();
 
   return (
     <div className="session-history">
@@ -39,7 +39,7 @@ const SessionHistory = () => {
         {sessionHistory.map((id) => (
           <li key={id} className={id === sessionId ? 'active' : ''}>
             <button type="button" onClick={() => switchSession(id)}>
-              {formatSessionId(id)}
+              {sessionTitles?.[id] || formatSessionId(id)}
             </button>
           </li>
         ))}


### PR DESCRIPTION
frontend: auto-name and persist chat session titles

- Add sessionTitles map in SessionContext with synchronous localStorage init/persist per user (`session_titles_<userId>`).
- Set session title from the first user message when a `session_id` is returned.
- Render titles in SessionHistory with timestamp fallback.
- Commit contains only: `frontend/src/context/SessionContext.jsx`, `frontend/src/components/ChatPage.jsx`, `frontend/src/components/SessionHistory.jsx`.

Why
- Improves discoverability of threads; titles survive refresh and navigation.
- Zero-flicker on page load due to sync init from localStorage.

Test
- Start app, create a new session, send first message → session list shows that text.
- Refresh → title persists.
- Switch sessions → correct titles render.